### PR TITLE
Just some fixes

### DIFF
--- a/Packages/10.2Tokyo/WiRLDesign.dpk
+++ b/Packages/10.2Tokyo/WiRLDesign.dpk
@@ -28,7 +28,7 @@ package WiRLDesign;
 {$DESCRIPTION 'WiRL REST components'}
 {$LIBSUFFIX '250'}
 {$DESIGNONLY}
-{$IMPLICITBUILD ON}
+{$IMPLICITBUILD OFF}
 
 requires
   rtl,

--- a/Packages/10.2Tokyo/WiRLDesign.dproj
+++ b/Packages/10.2Tokyo/WiRLDesign.dproj
@@ -53,6 +53,7 @@
         <DCC_K>false</DCC_K>
         <DCC_Description>WiRL REST components</DCC_Description>
         <DllSuffix>250</DllSuffix>
+        <DCC_OutputNeverBuildDcps>true</DCC_OutputNeverBuildDcps>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>rtl;WiRLRunTime;$(DCC_UsePackage)</DCC_UsePackage>

--- a/Source/Client/WiRL.Client.CustomResource.pas
+++ b/Source/Client/WiRL.Client.CustomResource.pas
@@ -279,7 +279,7 @@ begin
       if Assigned(AOnException) then
         AOnException(E)
       else
-        raise Exception.Create(E.Message);
+        raise;
     end;
   end;
 end;
@@ -313,7 +313,7 @@ begin
       if Assigned(AOnException) then
         AOnException(E)
       else
-        raise Exception.Create(E.Message);
+        raise;
     end;
   end;
 end;
@@ -346,7 +346,7 @@ begin
       if Assigned(AOnException) then
         AOnException(E)
       else
-        raise Exception.Create(E.Message);
+        raise;
     end;
   end;
 end;
@@ -382,12 +382,12 @@ begin
       LResponseStream.Free;
     end;
   except
-    on E:Exception do
+    on E: Exception do
     begin
       if Assigned(AOnException) then
         AOnException(E)
       else
-        raise Exception.Create(E.Message);
+        raise;
     end;
   end;
 end;
@@ -489,7 +489,7 @@ begin
       if Assigned(AOnException) then
         AOnException(E)
       else
-        raise Exception.Create(E.Message);
+        raise;
     end;
   end;
 end;
@@ -525,12 +525,12 @@ begin
       LContent.Free;
     end;
   except
-    on E:Exception do
+    on E: Exception do
     begin
       if Assigned(AOnException) then
         AOnException(E)
       else
-        raise Exception.Create(E.Message);
+        raise;
     end;
   end;
 end;
@@ -585,12 +585,12 @@ begin
       LContent.Free;
     end;
   except
-    on E:Exception do
+    on E: Exception do
     begin
       if Assigned(AOnException) then
         AOnException(E)
       else
-        raise Exception.Create(E.Message);
+        raise;
     end;
   end;
 end;

--- a/Source/Client/WiRL.http.Client.Indy.pas
+++ b/Source/Client/WiRL.http.Client.Indy.pas
@@ -203,6 +203,7 @@ var
   i: Integer;
 begin
   // Copy custom headers
+  FHttpClient.Request.CustomHeaders.Clear;
   for i := 0 to FRequest.FHeaderFields.Count - 1 do
   begin
     FHttpClient.Request.CustomHeaders.AddValue(


### PR DESCRIPTION
- Set WiRLDesign package to be "Explicit rebuild" (as it was before renaming)
- Bug fix: WiRL client - clear backend custom headers when adding WiRL header fields
- Bug fix: WiRL client - on REST methods calls, re-raise original exception if no exception handler is given -> this one must be examined as I suspect the original intent was to not directly pass Indy (or any other backend should be added in the future) exceptions to the user code, but there are cases when I want to raise a specific exception in the OnBeforeCommand event handler and catch it when I work on resources. My mods work with my code, but maybe we should find another solution if hiding backend exceptions is a must-be goal.