### PR TITLE
TWiRLClient: stop Indy adding its own Authorization token, other minor changes

### DIFF
--- a/Source/Client/WiRL.http.Client.Indy.pas
+++ b/Source/Client/WiRL.http.Client.Indy.pas
@@ -119,6 +119,7 @@ end;
 constructor TWiRLClientIndy.Create;
 begin
   FHttpClient := TIdHTTP.Create(nil);
+  FHttpClient.MaxAuthRetries := -1;
   FHttpClient.HTTPOptions := FHttpClient.HTTPOptions + [hoNoProtocolErrorException, hoWantProtocolErrorContent];
 
   FRequest := TWiRLClientRequestIndy.Create(FHttpClient.Request);

--- a/Source/Client/WiRL.http.Client.pas
+++ b/Source/Client/WiRL.http.Client.pas
@@ -60,8 +60,8 @@ type
     procedure SetClientVendor(const Value: string);
     function GetClientImplementation: TObject;
   protected
-    procedure DoBeforeCommand;
-    procedure DoAfterCommand;
+    procedure DoBeforeCommand; virtual;
+    procedure DoAfterCommand; virtual;
     procedure CheckResponse;
 {$IFDEF HAS_SYSTEM_THREADING}
     property WorkerTask: ITask read FWorkerTask;


### PR DESCRIPTION
By default, if, for any reason, you try to operate on a resource you're not authorized to access to, Indy will create an instance of TIdAuthenticationClass' type into Request.Authentication that will, from now on, overwrite your Authorization header with its own (empty) Basic request, preventing any other authorized access to the server.
Forcing IdHTTP's MaxAuthRetries to -1 inhibits this behaviour, giving you full control over Headers' contents.