### PR TITLE
WiRL Tests: fixed WiRL Mock Server

### DIFF
--- a/Tests/Mock/WiRL.Tests.Mock.Server.pas
+++ b/Tests/Mock/WiRL.Tests.Mock.Server.pas
@@ -49,8 +49,10 @@ type
     function GetListener: IWiRLListener;
     procedure SetListener(AValue: IWiRLListener);
 
+
     constructor Create;
     destructor Destroy; override;
+    function GetServerImplementation: TObject;
   end;
 
   {
@@ -212,6 +214,11 @@ end;
 function TWiRLTestServer.GetPort: Word;
 begin
   Result := 80;
+end;
+
+function TWiRLTestServer.GetServerImplementation: TObject;
+begin
+  Result := nil;
 end;
 
 function TWiRLTestServer.GetThreadPoolSize: Integer;

--- a/Tests/Mock/WiRL.Tests.Mock.Server.pas
+++ b/Tests/Mock/WiRL.Tests.Mock.Server.pas
@@ -48,11 +48,10 @@ type
     procedure SetThreadPoolSize(AValue: Integer);
     function GetListener: IWiRLListener;
     procedure SetListener(AValue: IWiRLListener);
-
+    function GetServerImplementation: TObject;
 
     constructor Create;
     destructor Destroy; override;
-    function GetServerImplementation: TObject;
   end;
 
   {


### PR DESCRIPTION
The implementation of the function GetServerImplementation for TWiRLTestServer is needed. See the IWiRLServer definition.