### PR TITLE
Solved a segmentation fault under linux (no error under windows)

### DIFF
--- a/Source/Core/WiRL.Core.Application.Worker.pas
+++ b/Source/Core/WiRL.Core.Application.Worker.pas
@@ -265,7 +265,7 @@ begin
     begin
       // If the request content stream is used as a param to a resource
       // it will be freed at the end process
-      if AValue.AsObject <> FContext.Request.ContentStream then
+      if (AValue.AsObject <> nil)and(AValue.AsObject <> FContext.Request.ContentStream) then
         if not TRttiHelper.HasAttribute<SingletonAttribute>(AValue.AsObject.ClassType) then
           AValue.AsObject.Free;
     end;


### PR DESCRIPTION
Authenticating via post request with wrong password returned:

{
    "status": 500,
    "exception": "EAccessViolation",
    "message": "Access violation at address 000000000061E2DA, accessing address 0000000000000000"
}

instead of :

{
    "status": 401,
    "exception": "EWiRLNotAuthorizedException",
    "message": "Invalid credentials",
    "data": {
        "issuer": "TBodyAuthResource",
        "method": "DoLogin"
    }
}

This was caused by a segmentation fault during garbage collecting (I've not dug enough to say why this seems to happen only under linux64 and not under windows)