### PR TITLE
Modified params decoding to accept international (english) floating point format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,3 @@ __recovery/
 # TestInsight config
 /Tests/Framework/Win32/TestInsight
 *.o
-
-# STC files and directories
-ClearDCU.bat
-.svn/

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ __recovery/
 # TestInsight config
 /Tests/Framework/Win32/TestInsight
 *.o
+
+# STC files and directories
+ClearDCU.bat
+.svn/

--- a/Source/Client/WiRL.http.Client.NetHttp.pas
+++ b/Source/Client/WiRL.http.Client.NetHttp.pas
@@ -152,6 +152,9 @@ end;
 
 destructor TWiRLClientNetHttp.Destroy;
 begin
+  FRequest.Free;
+  FResponse.Free;
+
   FHttpClient.Free;
   inherited;
 end;

--- a/Source/Core/WiRL.Core.Application.Worker.pas
+++ b/Source/Core/WiRL.Core.Application.Worker.pas
@@ -816,7 +816,7 @@ begin
   if LValue.IsEmpty then
     Result := 0
   else
-    Result := StrToFloat(LValue);
+    Result := StrToFloat(LValue, TFormatSettings.Invariant);
 end;
 
 function TWiRLApplicationWorker.TParamReader.AsBoolean(AAttr: TCustomAttribute): Boolean;


### PR DESCRIPTION
Floating point number format accepted in queryparams were bound to the server's locale, while it's a good idea for the server to use the anglo notation, like in json, i.e. "123.456" instead of "123,456" (Italian notation).
Note that this change can break compatibility with code written so far, so maybe it could be changed a bit to try both anglo and current locales when converting.