### PR TITLE
Bug Fix in Basic Auth header string generation

### DIFF
--- a/Source/Client/WiRL.Client.CustomResource.pas
+++ b/Source/Client/WiRL.Client.CustomResource.pas
@@ -343,7 +343,7 @@ end;
 
 function TWiRLClientCustomResource.MergeHeaders(const AHttpMethod: string): IWiRLHeaders;
 
-  function HasResponseBody(const AHttpMethod: string): Boolean;
+  function HasRequestBody(const AHttpMethod: string): Boolean;
   begin
     if (AHttpMethod = 'POST') or (AHttpMethod = 'PUT') then
       Result := True
@@ -357,7 +357,7 @@ begin
   Result := TWiRLHeaders.Create;
   if Accept <> '' then
     Result.Accept := Accept;
-  if HasResponseBody(AHttpMethod) and (ContentType <> '') then
+  if HasRequestBody(AHttpMethod) and (ContentType <> '') then
     Result.ContentType := ContentType;
 
   for LHeader in FHeaders do

--- a/Source/Core/WiRL.Core.Classes.pas
+++ b/Source/Core/WiRL.Core.Classes.pas
@@ -47,6 +47,8 @@ type
 
   // Basic authentication helper
   TBasicAuth = record
+  private const
+    AUTH_BASIC = 'Basic ';
   private
     FUser: string;
     FPassword: string;
@@ -124,13 +126,18 @@ begin
 end;
 
 class operator TBasicAuth.Implicit(AAuth: TBasicAuth): string;
+var
+  LBase64Enc: TBase64Encoding;
 begin
-  Result := 'Basic ' + TNetEncoding.Base64.Encode(AAuth.FUser + ':' + AAuth.FPassword);
+  LBase64Enc := TBase64Encoding.Create(0);
+  try
+    Result := AUTH_BASIC + LBase64Enc.Encode(AAuth.FUser + ':' + AAuth.FPassword);
+  finally
+    LBase64Enc.Free;
+  end;
 end;
 
 class operator TBasicAuth.Implicit(AAuth: string): TBasicAuth;
-const
-  AUTH_BASIC = 'Basic ';
 var
   LAuthField: string;
   LColonIdx: Integer;

--- a/Source/Core/WiRL.Core.Classes.pas
+++ b/Source/Core/WiRL.Core.Classes.pas
@@ -63,6 +63,8 @@ type
 
   // Bearer authentication helper
   TBearerAuth = record
+  private const
+    AUTH_BEARER = 'Bearer ';
   private
     FToken: string;
   public
@@ -168,12 +170,10 @@ end;
 
 class operator TBearerAuth.Implicit(AAuth: TBearerAuth): string;
 begin
-  Result := 'Bearer ' + AAuth.FToken;
+  Result := AUTH_BEARER + AAuth.FToken;
 end;
 
 class operator TBearerAuth.Implicit(AAuth: string): TBearerAuth;
-const
-  AUTH_BEARER = 'Bearer ';
 begin
   if not AAuth.StartsWith(AUTH_BEARER) then
     raise EWiRLException.Create('Authentication header error: wrong authentication type');


### PR DESCRIPTION
If long authentication credentials (user name + password) are issued, the Base64 encoding employed was splitting resulting string into 76 characters chunks (Base64 encoding's default behaviour), causing problems in the http headers.

Fixed by setting the Base64 max line length to infinite.