### PR TITLE
Fixed a bug preventing correct interpretation of JWTs with default values

### DIFF
--- a/Source/Core/WiRL.Core.JSON.pas
+++ b/Source/Core/WiRL.Core.JSON.pas
@@ -97,10 +97,17 @@ end;
 
 class procedure TJSONHelper.JSONCopyFrom(ASource, ADestination: TJSONObject);
 var
-  LPair: TJSONPair;
+  LPairSrc, LPairDst: TJSONPair;
 begin
-  for LPair in ASource do
-    ADestination.AddPair(TJSONPair(LPair.Clone));
+  for LPairSrc in ASource do
+  begin
+    LPairDst := ADestination.Get(LPairSrc.JsonString.Value);
+    if Assigned(LPairDst) then
+      // Replace the JSON Value (the previous is freed by the TJSONPair object)
+      LPairDst.JsonValue := TJSONValue(LPairSrc.JsonValue.Clone)
+    else
+      ADestination.AddPair(TJSONPair(LPairSrc.Clone));
+  end;
 end;
 
 class function TJSONHelper.Print(AJSONValue: TJSONValue; APretty: Boolean): string;

--- a/Source/Core/WiRL.Core.MessageBodyReader.pas
+++ b/Source/Core/WiRL.Core.MessageBodyReader.pas
@@ -41,7 +41,7 @@ type
     ///   Read a type from the HTTP Request stream
     /// </summary>
     function ReadFrom(AType: TRttitype; AMediaType: TMediaType;
-  	  AHeaders: IWiRLHeaders; AContentStream: TStream): TValue; overload;
+      AHeaders: IWiRLHeaders; AContentStream: TStream): TValue; overload;
 
     /// <summary>
     ///   Read a type from the HTTP Request stream.
@@ -51,7 +51,7 @@ type
     ///   already exists!
     /// </remarks>
     procedure ReadFrom(AObject: TObject; AType: TRttitype; AMediaType: TMediaType;
-	    AHeaders: IWiRLHeaders; AContentStream: TStream); overload;
+      AHeaders: IWiRLHeaders; AContentStream: TStream); overload;
   end;
 
   TIsReadableFunction = reference to function(AType: TRttiType;
@@ -115,7 +115,7 @@ type
 
   TMessageBodyReaderRegistry = class(TWiRLReaderRegistry)
   private type
-    TWiRLRegistrySingleton = TWiRLSingleton<TMessageBodyReaderRegistry>;
+    TMessageBodyReaderRegistrySingleton = TWiRLSingleton<TMessageBodyReaderRegistry>;
   private
     class function GetInstance: TMessageBodyReaderRegistry; static; inline;
   public
@@ -267,7 +267,7 @@ end;
 
 class function TMessageBodyReaderRegistry.GetInstance: TMessageBodyReaderRegistry;
 begin
-  Result := TWiRLRegistrySingleton.Instance;
+  Result := TMessageBodyReaderRegistrySingleton.Instance;
 end;
 
 procedure TMessageBodyReaderRegistry.RegisterReader(

--- a/Source/Core/WiRL.Core.MessageBodyWriter.pas
+++ b/Source/Core/WiRL.Core.MessageBodyWriter.pas
@@ -111,7 +111,7 @@ type
 
   TMessageBodyWriterRegistry = class(TWiRLWriterRegistry)
   private type
-    TWiRLRegistrySingleton = TWiRLSingleton<TMessageBodyWriterRegistry>;
+    TMessageBodyWriterRegistrySingleton = TWiRLSingleton<TMessageBodyWriterRegistry>;
   private
     class function GetInstance: TMessageBodyWriterRegistry; static; inline;
   public
@@ -365,7 +365,7 @@ end;
 
 class function TMessageBodyWriterRegistry.GetInstance: TMessageBodyWriterRegistry;
 begin
-  Result := TWiRLRegistrySingleton.Instance;
+  Result := TMessageBodyWriterRegistrySingleton.Instance;
 end;
 
 procedure TMessageBodyWriterRegistry.RegisterWriter(const ACreateInstance:

--- a/Source/Extensions/WiRL.Diagnostics.Manager.pas
+++ b/Source/Extensions/WiRL.Diagnostics.Manager.pas
@@ -72,7 +72,7 @@ type
 
   TWiRLDiagnosticsManager = class(TNonInterfacedObject, IWiRLHandleListener, IWiRLHandleRequestEventListener)
   private
-    type TDiagnosticsManagerSingleton = TWiRLSingleton<TWiRLDiagnosticsManager>;
+    type TWiRLDiagnosticsManagerSingleton = TWiRLSingleton<TWiRLDiagnosticsManager>;
   private
     class var FEngine: TWiRLEngine;
     FEngineInfo: TWiRLDiagnosticEngineInfo;
@@ -141,7 +141,7 @@ end;
 
 constructor TWiRLDiagnosticsManager.Create;
 begin
-  TDiagnosticsManagerSingleton.CheckInstance(Self);
+  TWiRLDiagnosticsManagerSingleton.CheckInstance(Self);
   FAppDictionary := TObjectDictionary<string, TWiRLDiagnosticAppInfo>.Create([doOwnsValues]);
   FCriticalSection := TCriticalSection.Create;
 
@@ -194,7 +194,7 @@ end;
 
 class function TWiRLDiagnosticsManager.GetInstance: TWiRLDiagnosticsManager;
 begin
-  Result := TDiagnosticsManagerSingleton.Instance;
+  Result := TWiRLDiagnosticsManagerSingleton.Instance;
 end;
 
 procedure TWiRLDiagnosticsManager.OnTokenEnd(const AToken: string);


### PR DESCRIPTION
If a JWT contains claims that are initialized with a default value in the constructor, some internal mechanisms that use copies of the Subject class would duplicate pairs containing such values, making the subsequent reading of that values incorrect (you'll only see the first pair's value in the JSON, which is the default one).
This was caused by TJSONHelper.JSONCopyFrom, that blindly copied all the Source pairs to the Destinatin, regardless of the latter containing same-name pairs as the Source.