### PR TITLE
Fixed Delphi compiler hint H2443

### DIFF
--- a/Source/Client/WiRL.Client.CustomResource.pas
+++ b/Source/Client/WiRL.Client.CustomResource.pas
@@ -14,7 +14,7 @@ unit WiRL.Client.CustomResource;
 interface
 
 uses
-  System.SysUtils, System.Classes, System.Rtti, System.Contnrs, System.Types,
+  System.SysUtils, System.Classes, System.Rtti, System.Contnrs, System.Types, System.TypInfo,
   System.Generics.Collections,
   WiRL.Core.Context,
   WiRL.Client.Application,


### PR DESCRIPTION
Fixed Delphi compiler hint: [dcc32 Hint] WiRL.Client.CustomResource.pas(603): H2443 Inline function 'TValue.GetTypeInfo' has not been expanded because unit 'System.TypInfo' is not specified in USES list