### PR TITLE
Fixed creation of error message in EWiRLClientResourceException:

### DIFF
--- a/Source/Client/WiRL.http.Client.Interfaces.pas
+++ b/Source/Client/WiRL.http.Client.Interfaces.pas
@@ -332,7 +332,7 @@ var
 begin
   FStatusCode := AResponse.StatusCode;
   FReasonString := AResponse.StatusText;
-  FServerException := Exception.ClassName;
+  FServerException := '';
   LMessage := FReasonString;
 
   if AResponse.ContentType = TMediaType.APPLICATION_JSON then
@@ -343,8 +343,8 @@ begin
       if not FJsonResponse.TryGetValue<string>('message', LMessage) then
         LMessage := FReasonString;
 
-      if not FJsonResponse.TryGetValue<string>('exception', FServerException) then
-        LMessage := FServerException;
+      if FJsonResponse.TryGetValue<string>('exception', FServerException) then
+        LMessage := FServerException + ', ' + LMessage;
     end;
   end;
 


### PR DESCRIPTION
 - Exception.ClassName always returned "Exception", defaul fixed to be empty string
 - FServerException did overwrite LMessage even when reading FServerException from JSON failed, few fixes for this:
   * If we want to include FServerException to LMessage we add it, we do not want to lose 'message' of JSON
   * We only add FServerException to LMessage if reading of 'exception' from JSON succeeds